### PR TITLE
✨ Update for the Portal ETL

### DIFF
--- a/kf_task_fhir_etl/etl/ingest.py
+++ b/kf_task_fhir_etl/etl/ingest.py
@@ -13,6 +13,7 @@ from kf_task_fhir_etl.target_api_plugins.entity_builders import (
     Organization,
     PractitionerRole,
     Patient,
+    ProbandStatus,
     FamilyRelationship,
     Family,
     ResearchStudy,
@@ -213,7 +214,13 @@ class Ingest:
                     with_merge_detail_dfs=False,
                     on=CONCEPT.STUDY.TARGET_SERVICE_ID,
                 )
-                study_all_targets.update([Patient, ResearchSubject])
+                study_all_targets.update(
+                    [
+                        Patient,
+                        ProbandStatus,
+                        ResearchSubject,
+                    ]
+                )
 
             # families
             families = study_mapped_df_dict.get("families")
@@ -372,7 +379,12 @@ class Ingest:
                     }
                 )
                 on = [CONCEPT.PARTICIPANT.TARGET_SERVICE_ID]
-                study_all_targets.update([SequencingCenter, Specimen])
+                study_all_targets.update(
+                    [
+                        SequencingCenter,
+                        Specimen,
+                    ]
+                )
 
                 if biospecimen_diagnoses is not None:
                     on.append(CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID)
@@ -457,6 +469,7 @@ class Ingest:
             ):
                 sequencing_experiments = sequencing_experiments.rename(
                     columns={
+                        "experiment_strategy": CONCEPT.SEQUENCING.STRATEGY,
                         "external_id": CONCEPT.SEQUENCING.ID,
                         "kf_id": CONCEPT.SEQUENCING.TARGET_SERVICE_ID,
                         "visible": CONCEPT.SEQUENCING.VISIBLE,

--- a/kf_task_fhir_etl/target_api_plugins/entity_builders/__init__.py
+++ b/kf_task_fhir_etl/target_api_plugins/entity_builders/__init__.py
@@ -8,6 +8,9 @@ from kf_task_fhir_etl.target_api_plugins.entity_builders.practitioner_role impor
     PractitionerRole,
 )
 from kf_task_fhir_etl.target_api_plugins.entity_builders.patient import Patient
+from kf_task_fhir_etl.target_api_plugins.entity_builders.proband_status import (
+    ProbandStatus,
+)
 from kf_task_fhir_etl.target_api_plugins.entity_builders.family_relationship import (
     FamilyRelationship,
 )

--- a/kf_task_fhir_etl/target_api_plugins/entity_builders/histopathology.py
+++ b/kf_task_fhir_etl/target_api_plugins/entity_builders/histopathology.py
@@ -4,6 +4,7 @@ from rows of tabular disease biospecimen association data.
 """
 from abc import abstractmethod
 
+from kf_lib_data_ingest.common import constants
 from kf_lib_data_ingest.common.concept_schema import CONCEPT
 from kf_task_fhir_etl.target_api_plugins.entity_builders import (
     Patient,
@@ -14,6 +15,14 @@ from kf_task_fhir_etl.common.utils import not_none, drop_none, yield_resource_id
 
 # http://hl7.org/fhir/ValueSet/observation-status
 status_code = "final"
+
+missing_data_values = {
+    "N/A",
+    constants.COMMON.NOT_APPLICABLE,
+    constants.COMMON.NOT_AVAILABLE,
+    constants.COMMON.NOT_REPORTED,
+    "Unavailable",
+}
 
 
 class Histopathology:
@@ -40,6 +49,7 @@ class Histopathology:
         biospecimen_diagnosis_id = record[
             CONCEPT.BIOSPECIMEN_DIAGNOSIS.TARGET_SERVICE_ID
         ]
+        tumor_descriptor = record.get(CONCEPT.BIOSPECIMEN.TUMOR_DESCRIPTOR)
 
         entity = {
             "resourceType": cls.api_path,
@@ -105,6 +115,9 @@ class Histopathology:
                 )
             },
         }
+
+        if tumor_descriptor and tumor_descriptor not in missing_data_values:
+            entity["valueCodeableConcept"] = {"text": tumor_descriptor}
 
         return entity
 

--- a/kf_task_fhir_etl/target_api_plugins/entity_builders/proband_status.py
+++ b/kf_task_fhir_etl/target_api_plugins/entity_builders/proband_status.py
@@ -1,0 +1,99 @@
+"""
+Builds FHIR Observation resources (https://www.hl7.org/fhir/observation.html)
+from rows of tabular participant broband status data.
+"""
+from abc import abstractmethod
+
+from kf_lib_data_ingest.common import constants
+from kf_lib_data_ingest.common.concept_schema import CONCEPT
+from kf_task_fhir_etl.target_api_plugins.entity_builders import Patient
+from kf_task_fhir_etl.common.utils import not_none, drop_none, yield_resource_ids
+
+# http://hl7.org/fhir/ValueSet/observation-status
+status_code = "final"
+
+# http://terminology.hl7.org/CodeSystem/v2-0136
+value_coding = {
+    constants.COMMON.TRUE: {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+        "code": "Y",
+        "display": "Yes",
+    },
+    constants.COMMON.FALSE: {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+        "code": "N",
+        "display": "No",
+    },
+}
+
+
+class ProbandStatus:
+    class_name = "proband_status"
+    api_path = "Observation"
+    target_id_concept = None
+    service_id_fields = None
+
+    @classmethod
+    def get_key_components(cls, record, get_target_id_from_record):
+        patient_id = not_none(get_target_id_from_record(Patient, record))
+        proband_status = not_none(record[CONCEPT.PARTICIPANT.IS_PROBAND])
+        assert proband_status in ["True", "False"]
+
+        return {
+            "code": "http://snomed.info/sct|85900004",
+            "subject": f"{Patient.api_path}/{patient_id}",
+        }
+
+    @classmethod
+    def build_entity(cls, record, get_target_id_from_record):
+        study_id = record[CONCEPT.STUDY.TARGET_SERVICE_ID]
+        proband_status = record[CONCEPT.PARTICIPANT.IS_PROBAND]
+
+        entity = {
+            "resourceType": cls.api_path,
+            "id": get_target_id_from_record(cls, record),
+            "meta": {
+                "profile": [f"http://hl7.org/fhir/StructureDefinition/{cls.api_path}"],
+                "tag": [{"code": study_id}],
+            },
+            "identifier": [
+                {
+                    "use": "official",
+                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/participants?is_proband=",
+                    "value": bool(proband_status),
+                }
+            ],
+            "status": status_code,
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "85900004",
+                        "display": "Proband (finding)",
+                    }
+                ],
+                "text": "Proband status",
+            },
+            "subject": {
+                "reference": "/".join(
+                    [
+                        Patient.api_path,
+                        not_none(get_target_id_from_record(Patient, record)),
+                    ]
+                )
+            },
+            "valueCodeableConcept": {
+                "coding": [value_coding[proband_status]],
+                "text": proband_status,
+            },
+        }
+
+        return entity
+
+    @classmethod
+    def query_target_ids(cls, host, key_components):
+        return list(yield_resource_ids(host, cls.api_path, drop_none(key_components)))
+
+    @abstractmethod
+    def submit(cls, host, body):
+        pass

--- a/kf_task_fhir_etl/target_api_plugins/entity_builders/proband_status.py
+++ b/kf_task_fhir_etl/target_api_plugins/entity_builders/proband_status.py
@@ -1,6 +1,6 @@
 """
 Builds FHIR Observation resources (https://www.hl7.org/fhir/observation.html)
-from rows of tabular participant broband status data.
+from rows of tabular participant proband status data.
 """
 from abc import abstractmethod
 

--- a/kf_task_fhir_etl/target_api_plugins/entity_builders/specimen.py
+++ b/kf_task_fhir_etl/target_api_plugins/entity_builders/specimen.py
@@ -453,12 +453,14 @@ class Specimen:
     def build_entity(cls, record, get_target_id_from_record):
         study_id = record[CONCEPT.STUDY.TARGET_SERVICE_ID]
         biospecimen_id = record[CONCEPT.BIOSPECIMEN.TARGET_SERVICE_ID]
-        external_aliquot_id = record[CONCEPT.BIOSPECIMEN.ID]
+        consent_type = record.get(CONCEPT.BIOSPECIMEN.CONSENT_SHORT_NAME)
+        dbgap_consent_code = record.get(CONCEPT.BIOSPECIMEN.DBGAP_STYLE_CONSENT_CODE)
+        external_sample_id = record.get(CONCEPT.BIOSPECIMEN_GROUP.ID)
+        external_aliquot_id = record.get(CONCEPT.BIOSPECIMEN.ID)
         tissue_type = record.get(CONCEPT.BIOSPECIMEN.TISSUE_TYPE)
         composition = record.get(CONCEPT.BIOSPECIMEN.COMPOSITION)
         analyte = record[CONCEPT.BIOSPECIMEN.ANALYTE]
         ncit_id_tissue_type = record.get(CONCEPT.BIOSPECIMEN.NCIT_TISSUE_TYPE_ID)
-        # tumor_descriptor = record.get(CONCEPT.BIOSPECIMEN.TUMOR_DESCRIPTOR)
         event_age_days = record.get(CONCEPT.BIOSPECIMEN.EVENT_AGE_DAYS)
         volume_ul = record.get(CONCEPT.BIOSPECIMEN.VOLUME_UL)
         sample_procurement = record.get(CONCEPT.BIOSPECIMEN.SAMPLE_PROCUREMENT)
@@ -492,10 +494,35 @@ class Specimen:
             },
         }
 
+        # meta.security
+        if consent_type:
+            entity["meta"].setdefault("security", []).append(
+                {
+                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/biospecimens?consent_type=",
+                    "code": consent_type,
+                }
+            )
+        if dbgap_consent_code:
+            entity["meta"].setdefault("security", []).append(
+                {
+                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/biospecimens?dbgap_consent_code=",
+                    "code": dbgap_consent_code,
+                }
+            )
+
         # identifier
+        if external_sample_id:
+            entity["identifier"].append(
+                {
+                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/biospecimens?external_sample_id=",
+                    "use": "secondary",
+                    "value": external_sample_id,
+                }
+            )
         if external_aliquot_id:
             entity["identifier"].append(
                 {
+                    "system": "https://kf-api-dataservice.kidsfirstdrc.org/biospecimens?external_aliquot_id=",
                     "use": "secondary",
                     "value": external_aliquot_id,
                 }

--- a/kf_task_fhir_etl/target_api_plugins/kf_api_fhir_service.py
+++ b/kf_task_fhir_etl/target_api_plugins/kf_api_fhir_service.py
@@ -9,6 +9,7 @@ from kf_task_fhir_etl.target_api_plugins.entity_builders import (
     Organization,
     PractitionerRole,
     Patient,
+    ProbandStatus,
     FamilyRelationship,
     Family,
     ResearchStudy,
@@ -98,6 +99,7 @@ Practitioner.submit = classmethod(submit)
 Organization.submit = classmethod(submit)
 PractitionerRole.submit = classmethod(submit)
 Patient.submit = classmethod(submit)
+ProbandStatus.submit = classmethod(submit)
 FamilyRelationship.submit = classmethod(submit)
 Family.submit = classmethod(submit)
 ResearchStudy.submit = classmethod(submit)
@@ -115,6 +117,7 @@ all_targets = [
     Organization,
     PractitionerRole,
     Patient,
+    ProbandStatus,
     FamilyRelationship,
     Family,
     ResearchStudy,


### PR DESCRIPTION
This PR adds:
- experiment strategy (See #10);
- tumor descriptor (See #11);
- proband status (See #12); and
- updates to Specimen (See #13)

It closes #10, #11, #12, and #13.